### PR TITLE
fix: AWG 2.0 H1-H4 range format and I1-I5 placement in peer confs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -96,11 +96,12 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ github.workflow }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ All env vars are saved to `/config/.donoteditthisfile` (LinuxServer pattern) for
 1. Set default in `init-amneziawg-confs/run` main logic section
 2. If persistent: add to `save_vars()` (as `ORIG_X`) AND the change detection `if` block
 3. For AWG params: also add to `generate_awg_params()` save block AND `load_awg_params()` grep section
-4. For config output: add to templates in `root/defaults/` (eval+heredoc expanded) or `append_awg_signatures()`
+4. For config output: add to templates in `root/defaults/` (eval+heredoc expanded), `append_awg_signatures()` (server conf — appends after template, before peer blocks), or `append_awg_signatures_to_interface()` (peer confs — inserts before `[Peer]` using awk)
 5. Document in `docker-compose.yml` (commented example) and `README.md`
 
 ### AWG obfuscation parameters
@@ -78,7 +78,7 @@ All clients and server must use identical values. Key constraints:
 - `AWG_VERSION`: `"2.0"` (default, S3/S4 random, I1 auto-generated) or `"1.5"` (S3=S4=0, no I1-I5)
 - `Jmin < Jmax`, `Jmax ≤ 1280`
 - `S1 ≤ 1132`, `S2 ≤ 1188`, `S1+56 ≠ S2`
-- `H1-H4` must be unique, all ≥ 5 (values 1-4 are standard WireGuard headers). AWG 2.0 supports range syntax (e.g., `H1=100-999`)
+- `H1-H4` must be unique, all ≥ 5 (values 1-4 are standard WireGuard headers). **AWG 2.0 generates non-overlapping quadrant range pairs by default** (e.g., `H1=90666522-140666522`) — the Amnezia app uses range format to identify AWG 2.0; single integers cause it to report AWG 1.5. AWG 1.5 keeps single integers.
 - `I1-I5` (AWG 2.0 signatures) use tag syntax with `=` signs — parse with `cut -d= -f2-` not `-f2`
 - Detailed parameter reference: `.claude/skills/docker-amneziawg/references/awg-parameters.md`
 
@@ -96,7 +96,7 @@ All clients and server must use identical values. Key constraints:
 **`docker-build.yml`** — main build pipeline:
 - Push to `master`/`main` → builds multi-arch (`amd64`, `arm64`) and pushes to `ghcr.io/ayastrebov/docker-amneziawg:latest` + upstream tools version tag
 - `v*` tags → semantic version tags (`1.0.0`, `1.0`, `1`)
-- PRs → build + comprehensive smoke tests (binaries, s6 structure, service types, dependency chain, CoreDNS, branding)
+- PRs → smoke tests only (single-platform `--load` build, no multi-arch QEMU): binaries, s6 structure, service types, dependency chain, CoreDNS, branding
 - `workflow_dispatch` accepts `amneziawg_go_version` and `amneziawg_tools_version` overrides
 
 **`upstream-check.yml`** — daily upstream version check (06:00 UTC):
@@ -120,3 +120,5 @@ Container images are tagged with the upstream `amneziawg-tools` version (e.g., `
 - `INTERFACE` is derived from `INTERNAL_SUBNET` (e.g., `10.13.13` from `10.13.13.0`) — not a separate env var
 - `svc-amneziawg` is a oneshot (not longrun) — tunnels stay up without a running process
 - Container branding: `root/etc/s6-overlay/s6-rc.d/init-adduser/branding` + `LSIO_FIRST_PARTY=false` in Dockerfile
+- I1-I5 must be in `[Interface]` in peer confs, not `[Peer]` — the Amnezia app only checks `[Interface]` for version detection. `append_awg_signatures_to_interface()` handles this via awk insertion before `[Peer]`. The server conf is fine with append since peer blocks haven't been added yet when signatures are written.
+- Custom `SERVERPORT` requires port mapping `SERVERPORT:51820/udp` (not `SERVERPORT:SERVERPORT/udp`) — the container always listens on 51820 internally regardless of `SERVERPORT`.

--- a/README.md
+++ b/README.md
@@ -159,12 +159,14 @@ These values modify the 4-byte type field at the start of each packet, making tr
 
 | Variable | Default | Constraints | Description |
 |----------|---------|-------------|-------------|
-| `AWG_H1` | Random | 5-2147483647, must be unique | Header value for handshake initiation |
-| `AWG_H2` | Random | 5-2147483647, must be unique | Header value for handshake response |
-| `AWG_H3` | Random | 5-2147483647, must be unique | Header value for cookie reply |
-| `AWG_H4` | Random | 5-2147483647, must be unique | Header value for transport data |
+| `AWG_H1` | Random range (AWG 2.0) / integer (1.5) | ≥ 5, must be unique | Header value for handshake initiation |
+| `AWG_H2` | Random range (AWG 2.0) / integer (1.5) | ≥ 5, must be unique | Header value for handshake response |
+| `AWG_H3` | Random range (AWG 2.0) / integer (1.5) | ≥ 5, must be unique | Header value for cookie reply |
+| `AWG_H4` | Random range (AWG 2.0) / integer (1.5) | ≥ 5, must be unique | Header value for transport data |
 
-**Note:** H1-H4 must all be different from each other. AWG 2.0 also supports range format (e.g., `AWG_H1=100-999`) for additional randomization per packet.
+**AWG 2.0:** H1-H4 are auto-generated as non-overlapping range pairs (e.g., `H1=90666522-140666522`) using a quadrant strategy. The Amnezia app uses range format to identify AWG 2.0 — single integers cause the app to report AWG 1.5 even with I1-I5 set. You can supply custom ranges via env vars (e.g., `AWG_H1=100000-50100000`).
+
+**AWG 1.5:** Single integers are used for backward compatibility.
 
 #### Signature Packets (AWG 2.0 Advanced)
 
@@ -194,10 +196,11 @@ environment:
   - AWG_S2=12
   - AWG_S3=25        # AWG 2.0 cookie padding
   - AWG_S4=15        # AWG 2.0 transport padding
-  - AWG_H1=1755269708
-  - AWG_H2=2101520157
-  - AWG_H3=1829552136
-  - AWG_H4=2016351429
+  # AWG 2.0: H1-H4 must use range format (non-overlapping quadrants)
+  - AWG_H1=142503-15687642
+  - AWG_H2=647372451-697372451
+  - AWG_H3=1173841824-1223841824
+  - AWG_H4=1687654321-1737654321
 ```
 
 ### AWG 2.0 Advanced Setup
@@ -497,6 +500,7 @@ services:
       - INTERNAL_SUBNET=10.13.13.0
       - ALLOWEDIPS=0.0.0.0/0, ::/0
       # Obfuscation - randomize these values for your setup
+      # Leave H1-H4 unset to auto-generate quadrant-based ranges (recommended)
       - AWG_JC=4
       - AWG_JMIN=50
       - AWG_JMAX=1000
@@ -504,10 +508,6 @@ services:
       - AWG_S2=89
       - AWG_S3=25
       - AWG_S4=0
-      - AWG_H1=985741236
-      - AWG_H2=1736482950
-      - AWG_H3=427819563
-      - AWG_H4=1293650847
       # AWG 2.0 - QUIC-like signature packet
       - AWG_I1=<b 0xc0000000><r 16><t>
     volumes:
@@ -542,6 +542,17 @@ services:
 - **Update regularly** - TSPU detection evolves; keep both server and client software up to date.
 
 ## Troubleshooting
+
+### Custom SERVERPORT: use `SERVERPORT:51820/udp` mapping
+
+The container always listens internally on port **51820**. When using a custom `SERVERPORT`, the Docker port mapping must forward the external port to the internal 51820:
+
+```yaml
+environment:
+  - SERVERPORT=32948
+ports:
+  - 32948:51820/udp  # external:internal — NOT 32948:32948/udp
+```
 
 ### No configuration files found
 

--- a/root/etc/s6-overlay/s6-rc.d/init-amneziawg-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-amneziawg-confs/run
@@ -68,18 +68,24 @@ generate_awg_params() {
     AWG_JMAX=${AWG_JMAX:-$(shuf -i 500-1000 -n 1)}
     AWG_S1=${AWG_S1:-$(shuf -i 15-150 -n 1)}
     AWG_S2=${AWG_S2:-$(shuf -i 15-150 -n 1)}
-    AWG_H1=${AWG_H1:-$(shuf -i 5-2147483647 -n 1)}
-    AWG_H2=${AWG_H2:-$(shuf -i 5-2147483647 -n 1)}
-    AWG_H3=${AWG_H3:-$(shuf -i 5-2147483647 -n 1)}
-    AWG_H4=${AWG_H4:-$(shuf -i 5-2147483647 -n 1)}
 
     if [[ "${AWG_VERSION}" == "2.0" ]]; then
+        # AWG 2.0: H1-H4 as non-overlapping range pairs (quadrant strategy, ~50M width each).
+        # Range format (e.g. "90666522-140666522") is required for the Amnezia app to detect AWG 2.0.
+        _h1_lo=$(shuf -i 5-486870911 -n 1);          AWG_H1=${AWG_H1:-${_h1_lo}-$((_h1_lo + 50000000))}
+        _h2_lo=$(shuf -i 536870912-1023741823 -n 1);  AWG_H2=${AWG_H2:-${_h2_lo}-$((_h2_lo + 50000000))}
+        _h3_lo=$(shuf -i 1073741824-1560612735 -n 1); AWG_H3=${AWG_H3:-${_h3_lo}-$((_h3_lo + 50000000))}
+        _h4_lo=$(shuf -i 1610612736-2097483647 -n 1); AWG_H4=${AWG_H4:-${_h4_lo}-$((_h4_lo + 50000000))}
         # AWG 2.0: S3/S4 padding and I1-I5 signatures
         AWG_S3=${AWG_S3:-$(shuf -i 15-150 -n 1)}
         AWG_S4=${AWG_S4:-$(shuf -i 15-150 -n 1)}
         generate_default_signatures
     else
-        # AWG 1.5 fallback: no S3/S4 padding, no signatures
+        # AWG 1.5 fallback: single integer H values, no S3/S4 padding, no signatures
+        AWG_H1=${AWG_H1:-$(shuf -i 5-2147483647 -n 1)}
+        AWG_H2=${AWG_H2:-$(shuf -i 5-2147483647 -n 1)}
+        AWG_H3=${AWG_H3:-$(shuf -i 5-2147483647 -n 1)}
+        AWG_H4=${AWG_H4:-$(shuf -i 5-2147483647 -n 1)}
         AWG_S3=${AWG_S3:-0}
         AWG_S4=${AWG_S4:-0}
         AWG_I1=${AWG_I1:-}
@@ -164,7 +170,7 @@ load_awg_params() {
     fi
 }
 
-# Append I1-I5 to a config file if set
+# Append I1-I5 to a config file if set (used for server conf, which has no [Peer] section yet)
 append_awg_signatures() {
     local conf_file=$1
     [[ -n "$AWG_I1" ]] && echo "I1 = ${AWG_I1}" >> "$conf_file"
@@ -172,6 +178,32 @@ append_awg_signatures() {
     [[ -n "$AWG_I3" ]] && echo "I3 = ${AWG_I3}" >> "$conf_file"
     [[ -n "$AWG_I4" ]] && echo "I4 = ${AWG_I4}" >> "$conf_file"
     [[ -n "$AWG_I5" ]] && echo "I5 = ${AWG_I5}" >> "$conf_file"
+}
+
+# Insert I1-I5 into [Interface] section of a peer conf (before the [Peer] line).
+# For AWG 2.0, I2-I5 are always written (even empty) so the Amnezia app detects AWG 2.0.
+append_awg_signatures_to_interface() {
+    local conf_file=$1
+    local sig_block=""
+    [[ -n "$AWG_I1" ]] && sig_block+="I1 = ${AWG_I1}"$'\n'
+    if [[ "${AWG_VERSION}" == "2.0" ]]; then
+        sig_block+="I2 = ${AWG_I2}"$'\n'
+        sig_block+="I3 = ${AWG_I3}"$'\n'
+        sig_block+="I4 = ${AWG_I4}"$'\n'
+        sig_block+="I5 = ${AWG_I5}"$'\n'
+    else
+        [[ -n "$AWG_I2" ]] && sig_block+="I2 = ${AWG_I2}"$'\n'
+        [[ -n "$AWG_I3" ]] && sig_block+="I3 = ${AWG_I3}"$'\n'
+        [[ -n "$AWG_I4" ]] && sig_block+="I4 = ${AWG_I4}"$'\n'
+        [[ -n "$AWG_I5" ]] && sig_block+="I5 = ${AWG_I5}"$'\n'
+    fi
+    [[ -z "$sig_block" ]] && return 0
+    local tmp
+    tmp=$(awk -v block="$sig_block" '
+        /^\[Peer\]/ && !done { printf "%s", block; done=1 }
+        { print }
+    ' "$conf_file")
+    printf '%s\n' "$tmp" > "$conf_file"
 }
 
 # ============================================================================
@@ -226,8 +258,8 @@ DUDE"
                 cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 $(cat /config/templates/peer.conf)
 DUDE"
-                # Append I1-I5 signature packets to peer conf
-                append_awg_signatures "/config/${PEER_ID}/${PEER_ID}.conf"
+                # Insert I1-I5 into [Interface] section of peer conf
+                append_awg_signatures_to_interface "/config/${PEER_ID}/${PEER_ID}.conf"
                 # add peer info to server conf with presharedkey
                 cat <<DUDE >> /config/wg_confs/wg0.conf
 [Peer]
@@ -242,8 +274,8 @@ DUDE
                 cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 $(sed '/PresharedKey/d' "/config/templates/peer.conf")
 DUDE"
-                # Append I1-I5 signature packets to peer conf
-                append_awg_signatures "/config/${PEER_ID}/${PEER_ID}.conf"
+                # Insert I1-I5 into [Interface] section of peer conf
+                append_awg_signatures_to_interface "/config/${PEER_ID}/${PEER_ID}.conf"
                 # add peer info to server conf without presharedkey
                 cat <<DUDE >> /config/wg_confs/wg0.conf
 [Peer]


### PR DESCRIPTION
## Problem

Two bugs in `init-amneziawg-confs/run` caused the Amnezia app to detect `AWG_VERSION=2.0` connections as **AWG 1.5** instead of AWG 2.0.

### Bug 1: H1-H4 single integers instead of range pairs

The Amnezia app distinguishes AWG 2.0 from 1.5 by checking whether H1-H4 use **range notation** (`LO-HI`, e.g. `H1 = 90666522-140666522`). Previously, all versions generated single integers via `shuf -i 5-2147483647 -n 1`.

**Fix:** For `AWG_VERSION=2.0`, generate non-overlapping range pairs using a quadrant strategy (~50M width each):
- H1 → Q1: `5–536870911`
- H2 → Q2: `536870912–1073741823`
- H3 → Q3: `1073741824–1610612735`
- H4 → Q4: `1610612736–2147483647`

Single integers are kept for `AWG_VERSION=1.5`.

### Bug 2: I1-I5 appended under `[Peer]` instead of `[Interface]`

`append_awg_signatures()` appended lines to the end of the peer conf file. Since the peer template already contains a `[Peer]` section, I1-I5 ended up *after* `AllowedIPs` — under `[Peer]` rather than `[Interface]`. The Amnezia app only checks `[Interface]` for I1-I5.

**Fix:** New `append_awg_signatures_to_interface()` uses `awk` to insert the I1-I5 block *before* the first `[Peer]` line. For `AWG_VERSION=2.0`, I2-I5 are always written (even when empty) as the app uses their presence to confirm AWG 2.0.

## Changes

- `root/etc/s6-overlay/s6-rc.d/init-amneziawg-confs/run`
  - Move H1-H4 generation inside the version branch; use quadrant ranges for 2.0, single ints for 1.5
  - Add `append_awg_signatures_to_interface()` (awk-based insertion before `[Peer]`)
  - Switch both peer-conf call sites from `append_awg_signatures` → `append_awg_signatures_to_interface`
  - Server conf call site (`append_awg_signatures /config/wg_confs/wg0.conf`) is unchanged — correct as-is

## Test

```bash
docker build -t amneziawg-test .
docker run -d --name awg-test --cap-add NET_ADMIN \
  -e PEERS=phone -e SERVERURL=test.example.com -e AWG_VERSION=2.0 \
  -v /tmp/awg-test:/config amneziawg-test
sleep 3
docker exec awg-test grep 'H[1-4]' /config/peer_phone/peer_phone.conf
# → H1 = NNNNN-NNNNN  (range format)
docker exec awg-test grep -A6 'H4' /config/peer_phone/peer_phone.conf
# → I1/I2/I3/I4/I5 appear before [Peer]
docker rm -f awg-test && rm -rf /tmp/awg-test
```