### PR TITLE
ci: ensure GHCR package visibility is public after each push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -115,6 +115,14 @@ jobs:
           provenance: false
           sbom: false
 
+      - name: Ensure package is public
+        if: github.event_name != 'pull_request'
+        run: |
+          gh api --method PATCH /user/packages/container/docker-amneziawg \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test image (PR only)
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
Packages created by GitHub Actions can silently default to private, causing a 404 when users try to pull the image (issue #3).

After each push to master, call the GitHub API to explicitly set the package visibility to public.

Closes #3