### PR TITLE
ci: remove package visibility step

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -115,14 +115,6 @@ jobs:
           provenance: false
           sbom: false
 
-      - name: Ensure package is public
-        if: github.event_name != 'pull_request'
-        run: |
-          gh api --method PATCH /user/packages/container/docker-amneziawg \
-            -f visibility=public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test image (PR only)
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
The `gh api PATCH /user/packages/container/docker-amneziawg` call fails with HTTP 404 because `GITHUB_TOKEN` in Actions is scoped to `github-actions[bot]`, not the repository owner, so `/user/packages/...` resolves to the bot's packages (none).

For a public repository, packages pushed by Actions automatically inherit the repository's visibility — the step was redundant and is now removed.