### PR TITLE
docs: add amneziawg-installer to Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ docker exec amneziawg /app/show-peer 1 2 3
 - [AmneziaWG Kernel Module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
 - [AmneziaWG-go](https://github.com/amnezia-vpn/amneziawg-go)
 - [AmneziaWG Tools](https://github.com/amnezia-vpn/amneziawg-tools)
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) — kernel-native Bash installer for AmneziaWG 2.0 on Ubuntu/Debian (+ ARM prebuilts)
 - [Advanced AWG Hub Guide](ADVANCED_AWG_HUB.md) — run server + client in one container for censorship bypass proxy
 - [LinuxServer docker-wireguard](https://github.com/linuxserver/docker-wireguard) (inspiration for this project)
 - [LinuxServer Advanced WireGuard Hub](https://www.linuxserver.io/blog/advanced-wireguard-hub) (inspiration for the hub guide)


### PR DESCRIPTION
## What

Adds a single bullet to the existing `## Links` section pointing to amneziawg-installer — a kernel-native Bash installer for AmneziaWG 2.0 on Ubuntu/Debian.

## Why

Users landing on this repo who want a bare-metal install (cheap VPS without Docker overhead, or ARM hosts like Raspberry Pi / Oracle Cloud Ampere / Hetzner CAX where DKMS install is the standard path) end up searching for an alternative. Adding the link here saves them the search and makes the AmneziaWG ecosystem easier to navigate.

The fit is complementary, not competing:
- This Docker container — userspace `amneziawg-go` in s6-overlay setup, multi-arch images, ideal for container-first homelabs
- amneziawg-installer — kernel module via DKMS, bare-metal Ubuntu 24.04 / 25.10 / Debian 12 / 13, ARM prebuilts since v5.9.0

Diff is one line under existing format.

## Affiliation

I am the author and maintainer of amneziawg-installer (full disclosure). Happy to drop the line or rephrase if it reads as out of scope for this README — your call.
