### PR TITLE
fix: align AWG 2.0 S3, S4, Jmax ranges with reference implementations

### DIFF
--- a/.claude/skills/docker-amneziawg/references/awg-parameters.md
+++ b/.claude/skills/docker-amneziawg/references/awg-parameters.md
@@ -14,7 +14,7 @@ Random data packets sent before each handshake to confuse traffic analysis.
 |-----------|------|---------|-------------|-------------|
 | `AWG_JC` | int | Random 3-8 | 1-128, recommended 4-12 | Number of junk packets per handshake |
 | `AWG_JMIN` | int | Random 40-80 | < JMAX | Minimum junk packet size in bytes |
-| `AWG_JMAX` | int | Random 500-1000 | ≤ 1280 | Maximum junk packet size in bytes |
+| `AWG_JMAX` | int | Random 80-250 | ≤ 1280 | Maximum junk packet size in bytes |
 
 **How it works**: Before initiating a handshake, the client sends `Jc` packets of random data with sizes between `Jmin` and `Jmax` bytes. This obscures the handshake pattern that DPI systems look for.
 
@@ -28,14 +28,14 @@ Adds padding bytes to different message types to obscure their true size.
 |-----------|------|---------|-------------|--------------|
 | `AWG_S1` | int | Random 15-150 | ≤ 1132 (1280-148) | Handshake initiation |
 | `AWG_S2` | int | Random 15-150 | ≤ 1188 (1280-92) | Handshake response |
-| `AWG_S3` | int | 0 | - | Cookie reply |
-| `AWG_S4` | int | 0 | - | Transport data |
+| `AWG_S3` | int | Random 8-55 (2.0) / 0 (1.5) | ≤ 64 | Cookie reply |
+| `AWG_S4` | int | Random 4-27 (2.0) / 0 (1.5) | ≤ 32 | Transport data (per-packet overhead, keep small) |
 
 **Critical constraint**: `S1 + 56 ≠ S2` (these values must not have this relationship)
 
 **How it works**: Each parameter specifies how many random padding bytes to add to that message type. This prevents DPI from identifying messages by their characteristic sizes.
 
-**Note**: S3 and S4 are typically left at 0 for most use cases. S1 and S2 provide sufficient obfuscation for handshakes.
+**Note**: S3 and S4 are AWG 2.0 extensions (set to 0 in AWG 1.5). S4 should be kept small (4-27) since it adds overhead to every data packet. S3 can be slightly larger (8-55) since cookie replies are rare.
 
 ### Header Obfuscation (H1, H2, H3, H4)
 
@@ -64,13 +64,13 @@ Modifies the 4-byte type field at the start of each packet.
 # Junk packets
 AWG_JC=${AWG_JC:-$(shuf -i 3-8 -n 1)}
 AWG_JMIN=${AWG_JMIN:-$(shuf -i 40-80 -n 1)}
-AWG_JMAX=${AWG_JMAX:-$(shuf -i 500-1000 -n 1)}
+AWG_JMAX=${AWG_JMAX:-$(shuf -i 80-250 -n 1)}
 
 # Padding
 AWG_S1=${AWG_S1:-$(shuf -i 15-150 -n 1)}
 AWG_S2=${AWG_S2:-$(shuf -i 15-150 -n 1)}
-AWG_S3=${AWG_S3:-0}
-AWG_S4=${AWG_S4:-0}
+AWG_S3=${AWG_S3:-$(shuf -i 8-55 -n 1)}   # AWG 2.0
+AWG_S4=${AWG_S4:-$(shuf -i 4-27 -n 1)}   # AWG 2.0, keep small (per-packet)
 
 # Headers (min 5 to avoid collision with standard WireGuard values 1-4)
 AWG_H1=${AWG_H1:-$(shuf -i 5-2147483647 -n 1)}
@@ -89,8 +89,8 @@ AWG_JMIN=62
 AWG_JMAX=847
 AWG_S1=98
 AWG_S2=45
-AWG_S3=0
-AWG_S4=0
+AWG_S3=25
+AWG_S4=12
 AWG_H1=1755269708
 AWG_H2=2101520157
 AWG_H3=1829552136
@@ -108,11 +108,11 @@ PrivateKey = ...
 # AmneziaWG Obfuscation Parameters
 Jc = 5
 Jmin = 62
-Jmax = 847
+Jmax = 180
 S1 = 98
 S2 = 45
-S3 = 0
-S4 = 0
+S3 = 25
+S4 = 12
 H1 = 1755269708
 H2 = 2101520157
 H3 = 1829552136

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ All env vars are saved to `/config/.donoteditthisfile` (LinuxServer pattern) for
 All clients and server must use identical values. Key constraints:
 - `AWG_VERSION`: `"2.0"` (default, S3/S4 random, I1 auto-generated) or `"1.5"` (S3=S4=0, no I1-I5)
 - `Jmin < Jmax`, `Jmax ≤ 1280`
-- `S1 ≤ 1132`, `S2 ≤ 1188`, `S1+56 ≠ S2`
+- `S1 ≤ 1132`, `S2 ≤ 1188`, `S1+56 ≠ S2`, `S3 ≤ 64`, `S4 ≤ 32` (S4 is per-packet overhead — keep small)
 - `H1-H4` must be unique, all ≥ 5 (values 1-4 are standard WireGuard headers). **AWG 2.0 generates non-overlapping quadrant range pairs by default** (e.g., `H1=90666522-140666522`) — the Amnezia app uses range format to identify AWG 2.0; single integers cause it to report AWG 1.5. AWG 1.5 keeps single integers.
 - `I1-I5` (AWG 2.0 signatures) use tag syntax with `=` signs — parse with `cut -d= -f2-` not `-f2`
 - Detailed parameter reference: `.claude/skills/docker-amneziawg/references/awg-parameters.md`

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Junk packets are random data sent before each handshake to confuse traffic analy
 |----------|---------|-------------|-------------|
 | `AWG_JC` | Random 3-8 | 1-128, recommended 4-12 | Number of junk packets to send before handshake initiation |
 | `AWG_JMIN` | Random 40-80 | < JMAX | Minimum junk packet size in bytes |
-| `AWG_JMAX` | Random 500-1000 | ≤ 1280 | Maximum junk packet size in bytes |
+| `AWG_JMAX` | Random 80-250 | ≤ 1280 | Maximum junk packet size in bytes |
 
 #### Packet Padding
 
@@ -150,8 +150,8 @@ Padding bytes are added to handshake and transport messages to obscure their tru
 |----------|---------|-------------|-------------|
 | `AWG_S1` | Random 15-150 | ≤ 1132, S1+56 ≠ S2 | Bytes added to handshake initiation message |
 | `AWG_S2` | Random 15-150 | ≤ 1188, S1+56 ≠ S2 | Bytes added to handshake response message |
-| `AWG_S3` | Random 15-150 (2.0) / 0 (1.5) | - | Bytes added to cookie reply message |
-| `AWG_S4` | Random 15-150 (2.0) / 0 (1.5) | - | Bytes added to transport data messages |
+| `AWG_S3` | Random 8-55 (2.0) / 0 (1.5) | ≤ 64 | Bytes added to cookie reply message |
+| `AWG_S4` | Random 4-27 (2.0) / 0 (1.5) | ≤ 32, keep small | Bytes added to transport data messages (per-packet overhead) |
 
 #### Header Obfuscation
 
@@ -191,11 +191,11 @@ environment:
   - AWG_VERSION=2.0  # Default; set to 1.5 for legacy clients
   - AWG_JC=4         # 3-8 recommended
   - AWG_JMIN=50
-  - AWG_JMAX=1000
+  - AWG_JMAX=200
   - AWG_S1=86
   - AWG_S2=12
-  - AWG_S3=25        # AWG 2.0 cookie padding
-  - AWG_S4=15        # AWG 2.0 transport padding
+  - AWG_S3=25        # AWG 2.0 cookie padding (8-55)
+  - AWG_S4=15        # AWG 2.0 transport padding (4-27, keep small)
   # AWG 2.0: H1-H4 must use range format (non-overlapping quadrants)
   - AWG_H1=142503-15687642
   - AWG_H2=647372451-697372451
@@ -303,7 +303,7 @@ DNS = 8.8.8.8
 # AmneziaWG parameters (must match server)
 Jc = 4
 Jmin = 50
-Jmax = 1000
+Jmax = 200
 S1 = 86
 S2 = 12
 S3 = 0
@@ -503,7 +503,7 @@ services:
       # Leave H1-H4 unset to auto-generate quadrant-based ranges (recommended)
       - AWG_JC=4
       - AWG_JMIN=50
-      - AWG_JMAX=1000
+      - AWG_JMAX=200
       - AWG_S1=67
       - AWG_S2=89
       - AWG_S3=25
@@ -536,7 +536,7 @@ services:
 
 - **Always randomize your own parameter values** - do not copy exact values from examples. The auto-generated random defaults in this container are a good starting point.
 - **Use AWG 2.0 with I1 signatures** when possible - it is significantly harder for TSPU to detect than AWG 1.0 junk packets alone.
-- **Keep S4 small** (0-32) - data packet padding is per-packet overhead, large values kill throughput.
+- **Keep S4 small** (4-27) - data packet padding is per-packet overhead, large values kill throughput.
 - **Consider split tunneling** (`ALLOWEDIPS=`) to route only necessary traffic through VPN, reducing the traffic profile.
 - **Have a fallback ready** - the Amnezia team recommends VLESS+Reality (XRay) as a backup protocol when AWG faces active blocking campaigns.
 - **Update regularly** - TSPU detection evolves; keep both server and client software up to date.

--- a/root/etc/s6-overlay/s6-rc.d/init-amneziawg-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-amneziawg-confs/run
@@ -65,7 +65,7 @@ generate_awg_params() {
     # Core parameters (all versions)
     AWG_JC=${AWG_JC:-$(shuf -i 3-8 -n 1)}
     AWG_JMIN=${AWG_JMIN:-$(shuf -i 40-80 -n 1)}
-    AWG_JMAX=${AWG_JMAX:-$(shuf -i 500-1000 -n 1)}
+    AWG_JMAX=${AWG_JMAX:-$(shuf -i 80-250 -n 1)}
     AWG_S1=${AWG_S1:-$(shuf -i 15-150 -n 1)}
     AWG_S2=${AWG_S2:-$(shuf -i 15-150 -n 1)}
 
@@ -77,8 +77,8 @@ generate_awg_params() {
         _h3_lo=$(shuf -i 1073741824-1560612735 -n 1); AWG_H3=${AWG_H3:-${_h3_lo}-$((_h3_lo + 50000000))}
         _h4_lo=$(shuf -i 1610612736-2097483647 -n 1); AWG_H4=${AWG_H4:-${_h4_lo}-$((_h4_lo + 50000000))}
         # AWG 2.0: S3/S4 padding and I1-I5 signatures
-        AWG_S3=${AWG_S3:-$(shuf -i 15-150 -n 1)}
-        AWG_S4=${AWG_S4:-$(shuf -i 15-150 -n 1)}
+        AWG_S3=${AWG_S3:-$(shuf -i 8-55 -n 1)}
+        AWG_S4=${AWG_S4:-$(shuf -i 4-27 -n 1)}
         generate_default_signatures
     else
         # AWG 1.5 fallback: single integer H values, no S3/S4 padding, no signatures


### PR DESCRIPTION
## Summary

- **S4 range: 15-150 → 4-27** — S4 pads every transport data packet. Values like 150 add 150 bytes overhead per packet, killing throughput. Both [pumbaX/awg-multi-script](https://github.com/pumbaX/awg-multi-script) (6-31) and [bivlked/amneziawg-installer](https://github.com/bivlked/amneziawg-installer) (4-27) cap S4 at ~27-31. Confirmed by [amneziawg-go source](https://github.com/amnezia-vpn/amneziawg-go) — `device.paddings.transport` is applied to every encrypted data packet in `RoutineEncryption()`.
- **S3 range: 15-150 → 8-55** — S3 pads cookie reply messages (rare, only during DDoS protection). Aligned with references (pumbaX: 8-64, bivlked: 8-55).
- **Jmax range: 500-1000 → 80-250** — Junk packets only occur during handshakes so impact is low, but our range was 2-5x larger than all references (pumbaX: 80-200, bivlked: Jmin+50-250). Smaller junk packets also reduce risk of being dropped on restrictive networks.

## References

| Parameter | Old | New | pumbaX | bivlked | amneziawg-go constraint |
|-----------|-----|-----|--------|---------|------------------------|
| S4 | 15-150 | 4-27 | 6-31 | 4-27 | No max, but per-packet |
| S3 | 15-150 | 8-55 | 8-64 | 8-55 | No max, cookie only |
| Jmax | 500-1000 | 80-250 | 80-200 | ~90-339 | No max, handshake only |

## Test plan

- [ ] Build image and verify auto-generated params are within new ranges
- [ ] Verify existing configs with custom env vars still override defaults
- [ ] Smoke test: `docker run` with `PEERS=1`, check `wg0.conf` and `peer1.conf` have correct S3/S4/Jmax values

🤖 Generated with [Claude Code](https://claude.com/claude-code)