### PR TITLE
ci: fix upstream-check PR permissions

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -95,9 +95,6 @@ jobs:
     needs: check-upstream
     if: needs.check-upstream.outputs.tools_changed == 'true' || needs.check-upstream.outputs.go_changed == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The update-and-build job had its own permissions block that overrode the top-level write permissions, causing PR creation to fail with 'Resource not accessible by integration'. Removing the job-level block lets the job inherit the top-level permissions.