### PR TITLE
docs: document AWG 3.1 interface options and restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,48 +5,28 @@
 [![GitHub release](https://img.shields.io/github/v/release/AYastrebov/docker-amneziawg)](https://github.com/AYastrebov/docker-amneziawg/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[AmneziaWG](https://docs.amnezia.org/) VPN container that generates configs, manages peers, and prints QR codes. Based on [LinuxServer.io](https://www.linuxserver.io/) base images with s6-overlay.
+[AmneziaWG](https://docs.amnezia.org/) VPN server and client in one container. It writes the server config and hands you a ready config plus QR code for every peer, and it can answer DNS for connected clients. Built on [LinuxServer.io](https://www.linuxserver.io/) base images with s6-overlay.
 
-AmneziaWG extends WireGuard with traffic obfuscation to bypass Deep Packet Inspection (DPI). AWG 2.0 (default) auto-generates all obfuscation parameters including Custom Protocol Signatures (I1-I5), so you don't need to configure them manually.
+AmneziaWG is WireGuard with added traffic obfuscation, so deep packet inspection has a harder time recognizing the handshake. The container picks random obfuscation values on first start, including the I1-I5 protocol signatures, then saves them and reuses them on later restarts so already distributed peer configs keep working.
 
-## Supported Architectures
+## Contents
 
-| Architecture | Available |
-|:---:|:---:|
-| x86-64 | amd64 |
-| arm64 | aarch64 |
+- [Quick start](#quick-start)
+- [Requirements](#requirements)
+- [Modes](#modes)
+- [Parameters](#parameters)
+- [Protocol version](#protocol-version)
+- [Obfuscation parameters](#obfuscation-parameters)
+- [Custom protocol signatures (I1-I5)](#custom-protocol-signatures-i1-i5)
+- [Custom SERVERPORT](#custom-serverport)
+- [Managing peers](#managing-peers)
+- [Support info](#support-info)
+- [Building locally](#building-locally)
+- [Links](#links)
 
-## Application Setup
+## Quick start
 
-The container runs in two modes:
-
-- **Server mode** — set `PEERS` to auto-generate server config, peer configs, and QR codes
-- **Client mode** — place `.conf` files in `./config/wg_confs/` (no `PEERS` needed)
-
-### Kernel Module
-
-For best performance, install the [AmneziaWG kernel module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) on your host (or rely on the in-tree `wireguard` module that ships with most modern kernels). The container auto-detects kernel support and falls back to the `amneziawg-go` userspace implementation when no module is loaded. `SYS_MODULE` is **not** required to use the kernel datapath — the container never calls `modprobe`. See the Parameters table below for when (if ever) you might want it.
-
-### AWG Protocol Version
-
-| Version | When to Use |
-|---------|-------------|
-| `2.0` (default) | Full DPI evasion with I1-I5 signatures. Requires AmneziaVPN app 4.8.12.9+ |
-| `3.0` | Adds header protection (`HeaderProtectionKey`), content padding and randomized protocol timers. Requires AWG 3.0-capable clients; `HeaderProtectionKey` must be identical on server and all clients |
-| `1.5` | Legacy compatibility with older clients. No I1-I5, S3=S4=0 |
-
-> **`AWG_VERSION=3.0` needs 3.0-capable software on both ends.** By default
-> the container runs 3.0 in userspace (`amneziawg-go`, bundled). It also runs
-> 3.0 in kernel mode automatically when a 3.0-capable
-> [amneziawg kernel module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
-> is loaded on the host — the generated config is identical either way.
-> Peers must use an AmneziaVPN app / amneziawg build that supports 3.0.
-
-Set via `AWG_VERSION` environment variable. All obfuscation parameters are randomized automatically — override only if you need specific values (e.g., to match an existing setup).
-
-## Usage
-
-### Docker Compose (recommended)
+Server mode, three peers, using Docker Compose:
 
 ```yaml
 services:
@@ -55,7 +35,7 @@ services:
     container_name: amneziawg
     cap_add:
       - NET_ADMIN
-      # - SYS_MODULE  # rarely needed — see Parameters table
+      # - SYS_MODULE  # rarely needed, see Parameters
     devices:
       - /dev/net/tun:/dev/net/tun
     environment:
@@ -81,13 +61,20 @@ services:
     restart: unless-stopped
 ```
 
-### Docker CLI
+```bash
+docker compose up -d
+docker exec amneziawg /app/show-peer laptop   # config text and QR code
+```
+
+Each peer also gets a file on disk, at `./config/peer_laptop/peer_laptop.conf` for named peers or `./config/peer1/peer1.conf` when `PEERS` is a number.
+
+The same thing with `docker run`:
 
 ```bash
 docker run -d \
   --name amneziawg \
   --cap-add NET_ADMIN \
-  `# --cap-add SYS_MODULE  rarely needed; see Parameters table` \
+  `# --cap-add SYS_MODULE  rarely needed, see Parameters` \
   --device /dev/net/tun:/dev/net/tun \
   -e PUID=1000 \
   -e PGID=1000 \
@@ -102,10 +89,30 @@ docker run -d \
   ghcr.io/ayastrebov/docker-amneziawg:latest
 ```
 
-### Client Mode
+## Requirements
+
+- A Docker host with `/dev/net/tun` and the `NET_ADMIN` capability
+- amd64 (x86-64) or arm64 (aarch64)
+
+### Kernel module
+
+The container works out of the box without a kernel module: it falls back to the bundled `amneziawg-go` userspace implementation. For better throughput, install the [AmneziaWG kernel module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) on the host and the container will detect it and use it instead.
+
+Keep the module and the image on the same feature generation. An older module still works with a newer image, but the kernel datapath only applies the options that module knows about.
+
+> [!NOTE]
+> `SYS_MODULE` is not required for the kernel datapath. The container never calls `modprobe`, it only checks whether the module is already loaded. See [Parameters](#parameters) for the one case where `SYS_MODULE` still helps.
+
+## Modes
+
+The container runs in one of two modes, decided by whether `PEERS` is set.
+
+Set `PEERS` and you get server mode. The container generates keys, writes `wg0.conf`, writes one config and QR code per peer, and starts CoreDNS so peers on `PEERDNS=auto` have a resolver to talk to.
+
+Leave `PEERS` unset and you get client mode. Drop your own `.conf` files into `./config/wg_confs/` and the container brings up every one of them on start. Nothing is generated, and CoreDNS stays off unless you ask for it.
 
 ```bash
-# Place your .conf file(s) in ./config/wg_confs/ and start:
+# client mode: your configs, nothing generated
 docker run -d \
   --name amneziawg \
   --cap-add NET_ADMIN \
@@ -126,7 +133,7 @@ docker run -d \
 | `-e PGID=1000` | Group ID for file ownership |
 | `-e TZ=Etc/UTC` | Timezone ([list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)) |
 | `-e SERVERURL=auto` | Server URL/IP for peer configs. `auto` detects external IP |
-| `-e SERVERPORT=51820` | Port advertised to peers. Use ≤ 9999 if your ISP blocks high UDP ports |
+| `-e SERVERPORT=51820` | Port advertised to peers. Use <= 9999 if your ISP blocks high UDP ports |
 | `-e PEERS=3` | Number or comma-separated names (`laptop,phone`). Enables server mode |
 | `-e PEERDNS=auto` | DNS for peers. `auto` = container's CoreDNS at subnet.1 |
 | `-e INTERNAL_SUBNET=10.13.13.0` | VPN subnet (.1 = server, .2+ = peers) |
@@ -134,17 +141,33 @@ docker run -d \
 | `-e PERSISTENTKEEPALIVE_PEERS=` | Which peers get keepalive: `all` or comma-separated names/numbers |
 | `-e SERVER_ALLOWEDIPS_PEER_X=` | Per-peer server AllowedIPs for site-to-site VPN |
 | `-e LOG_CONFS=true` | Show generated configs and QR codes in container logs |
-| `-e USE_COREDNS=true` | Enable/disable built-in CoreDNS. Defaults to `true` in server mode, `false` in client mode. Auto-disables when port 53 is already bound unless explicitly set. **Warning:** setting `false` in server mode breaks DNS for peers that use `PEERDNS=auto` (the default) — set `PEERDNS` to a public resolver like `1.1.1.1` if you disable CoreDNS |
-| `-e AWG_VERSION=2.0` | Protocol version: `2.0` (default, full DPI evasion), `3.0` (header protection + randomized timers) or `1.5` (legacy) |
+| `-e USE_COREDNS=true` | Enable or disable the built-in CoreDNS. Defaults to `true` in server mode and `false` in client mode. Auto-disables when port 53 is already bound, unless you set it explicitly. Setting it to `false` in server mode breaks DNS for peers on `PEERDNS=auto`, so point `PEERDNS` at a public resolver such as `1.1.1.1` if you do |
+| `-e AWG_VERSION=2.0` | Protocol version: `2.0` (default, full DPI evasion), `3.0` (header protection and randomized timers) or `1.5` (legacy) |
 | `-v /config` | Persistent config volume |
 | `--cap-add NET_ADMIN` | Required for tunnel management |
-| `--cap-add SYS_MODULE` | Usually not needed. The container does **not** load kernel modules itself — it only checks whether `wireguard`/`amneziawg` is already loaded on the host. Keep `SYS_MODULE` only on minimal hosts that don't auto-load iptables NAT modules. |
+| `--cap-add SYS_MODULE` | Usually unnecessary. The container does not load kernel modules, it only checks whether `wireguard`/`amneziawg` is already loaded on the host. Keep `SYS_MODULE` only on minimal hosts that do not auto-load iptables NAT modules |
 | `--sysctl net.ipv4.ip_forward=1` | Enable IP forwarding |
 | `--device /dev/net/tun` | TUN device access |
 
-### AmneziaWG Obfuscation Parameters
+## Protocol version
 
-All parameters are optional — random values are generated automatically. Server and all clients must use identical values (timer parameters excepted: each side may use its own).
+| Version | When to use |
+|---------|-------------|
+| `2.0` (default) | Full DPI evasion with I1-I5 signatures. Requires AmneziaVPN app 4.8.12.9+ |
+| `3.0` | Adds header protection (`HeaderProtectionKey`), content padding and randomized protocol timers. Requires 3.0-capable clients, and `HeaderProtectionKey` must be identical on server and all clients |
+| `1.5` | Legacy compatibility with older clients. No I1-I5, S3=S4=0 |
+
+Set this with the `AWG_VERSION` environment variable. Every obfuscation value is randomized for you, so override them only to match an existing setup.
+
+> [!IMPORTANT]
+> `AWG_VERSION=3.0` needs 3.0-capable software at both ends. The container handles its own side either way: it runs 3.0 in userspace with the bundled `amneziawg-go`, and switches to the kernel datapath automatically when a 3.0-capable module is loaded on the host. The generated config is the same in both cases. Your peers need an AmneziaVPN app or amneziawg build that supports 3.0.
+
+> [!NOTE]
+> There is no `AWG_VERSION=3.1`. AWG 3.1 added two independent `[Interface]` switches rather than a new parameter set, and the container does not generate them. See [AWG 3.1 interface options](#awg-31-interface-options).
+
+## Obfuscation parameters
+
+Every value here is optional and random by default. Server and clients must agree on all of them, except the 3.0 timer ranges, where each side draws its own value.
 
 | Parameter | Default | Constraints |
 |-----------|---------|-------------|
@@ -154,34 +177,47 @@ All parameters are optional — random values are generated automatically. Serve
 | `-e AWG_S1=` | Random 15-150 | Init padding bytes (max 1132). S1+56 must not equal S2 |
 | `-e AWG_S2=` | Random 15-150 | Response padding bytes (max 1188) |
 | `-e AWG_S3=` | Random 8-55 (2.0) / 12-55 (3.0) / 0 (1.5) | Cookie padding bytes (max 64) |
-| `-e AWG_S4=` | Random 4-27 (2.0) / 12-27 (3.0) / 0 (1.5) | Transport padding bytes (max 32). Per-packet overhead — keep small |
+| `-e AWG_S4=` | Random 4-27 (2.0) / 12-27 (3.0) / 0 (1.5) | Transport padding bytes (max 32). Per-packet overhead, keep it small |
 | `-e AWG_H1=` | Auto range (2.0) / int (1.5) | Header obfuscation. H1-H4 must be unique, all >= 5 |
 | `-e AWG_H2=` | Auto range (2.0) / int (1.5) | AWG 2.0 uses range format (e.g. `90666522-140666522`) |
 | `-e AWG_H3=` | Auto range (2.0) / int (1.5) | Single integers cause the Amnezia app to report AWG 1.5 |
 | `-e AWG_H4=` | Auto range (2.0) / int (1.5) | |
-| `-e AWG_I1=` | Auto QUIC Initial (2.0) / empty (1.5) | Custom Protocol Signature packet. See [CPS tag reference](#custom-protocol-signatures-i1-i5) |
+| `-e AWG_I1=` | Auto QUIC Initial (2.0) / empty (1.5) | Custom protocol signature packet. See [tag reference](#custom-protocol-signatures-i1-i5) |
 | `-e AWG_I2=` | empty | Requires I1 to be set |
 | `-e AWG_I3=` | empty | |
 | `-e AWG_I4=` | empty | |
 | `-e AWG_I5=` | empty | |
 
-#### AWG 3.0 parameters
+### AWG 3.0 parameters
 
-Only generated when `AWG_VERSION=3.0`. Timer values are `lo-hi` ranges — the endpoint picks a fresh random value in that range, so each side may use its own.
+Generated only when `AWG_VERSION=3.0`. Timer values are `lo-hi` ranges and the endpoint picks a fresh random value inside the range, so the two sides do not have to match.
 
 | Parameter | Default | Constraints |
 |-----------|---------|-------------|
-| `-e AWG_HEADER_PROTECTION_KEY=` | Auto-generated shared key (3.0) | Encrypts packet headers. Must be identical on server and all clients. Requires S1-S4 >= 12 |
-| `-e AWG_CONTENT_PADDING=` | Random range within 16-128 (3.0) | Extra random padding per transport packet, `lo-hi` bytes. `0` disables |
-| `-e AWG_REKEY_AFTER_TIME=` | Random range within 100-145s (3.0) | Time before initiator rekeys, `lo-hi` seconds (WireGuard default 120) |
-| `-e AWG_REKEY_TIMEOUT=` | Random range within 4-10s (3.0) | Handshake retransmit timeout, `lo-hi` seconds (default 5) |
-| `-e AWG_REJECT_AFTER_TIME=` | Random range, derived (3.0) | Keypair lifetime, `lo-hi` seconds (default 180). Must exceed RekeyAfterTime and KeepaliveTimeout + RekeyTimeout |
-| `-e AWG_KEEPALIVE_TIMEOUT=` | Random range within 8-22s (3.0) | Keepalive interval when idle, `lo-hi` seconds (default 10) |
-| `-e AWG_MAX_HANDSHAKE_ATTEMPTS=` | Random range within 12-28 (3.0) | Handshake retries before giving up, `lo-hi` count (default 18) |
+| `-e AWG_HEADER_PROTECTION_KEY=` | Auto-generated shared key | Encrypts packet headers. Must be identical on server and all clients. Requires S1-S4 >= 12 |
+| `-e AWG_CONTENT_PADDING=` | Random range within 16-128 | Extra random padding per transport packet, `lo-hi` bytes. `0` disables |
+| `-e AWG_REKEY_AFTER_TIME=` | Random range within 100-145s | Time before the initiator rekeys, `lo-hi` seconds (WireGuard default 120) |
+| `-e AWG_REKEY_TIMEOUT=` | Random range within 4-10s | Handshake retransmit timeout, `lo-hi` seconds (default 5) |
+| `-e AWG_REJECT_AFTER_TIME=` | Random range, derived | Keypair lifetime, `lo-hi` seconds (default 180). Must exceed RekeyAfterTime and KeepaliveTimeout + RekeyTimeout |
+| `-e AWG_KEEPALIVE_TIMEOUT=` | Random range within 8-22s | Keepalive interval when idle, `lo-hi` seconds (default 10) |
+| `-e AWG_MAX_HANDSHAKE_ATTEMPTS=` | Random range within 12-28 | Handshake retries before giving up, `lo-hi` count (default 18) |
 
-### Custom Protocol Signatures (I1-I5)
+### AWG 3.1 interface options
 
-AWG 2.0 sends CPS packets before handshakes to masquerade VPN traffic as another UDP protocol. I1 is auto-generated as a QUIC Initial packet (RFC 9000) by default.
+The bundled `amneziawg-go` and `awg` are 3.1 builds, which accept two extra `[Interface]` booleans (`on` or `off`). They work with any `AWG_VERSION` and the container does not write them for you. Add them by hand to `/config/templates/server.conf` and `/config/templates/peer.conf`, anywhere above the `[Peer]` section, or to your own `.conf` files in client mode.
+
+| Option | Effect | Must match on both ends |
+|--------|--------|:---:|
+| `RandomTrailers = on` | Appends a random number of random bytes to handshake initiation, response and cookie-reply packets, so those packets no longer have a fixed length. The trailer is drawn per packet to fill up to a 500-byte window | Yes |
+| `DisableCookies = on` | Stops the endpoint from answering with cookie-reply messages when it is under load, which removes a distinctive response to probing. You give up WireGuard's built-in DoS mitigation in exchange | No |
+
+`RandomTrailers` changes the receive path as well as the send path. A peer without it expects handshake packets of exactly one length and drops the padded ones, so enable it on the server and every peer, or on none of them.
+
+Both options need 3.1-capable software wherever they are used: the bundled userspace `amneziawg-go`, or [kernel module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) v3.1.x on the host for the kernel datapath. Older `awg` builds reject the keys with `Line unrecognized`.
+
+## Custom protocol signatures (I1-I5)
+
+AWG 2.0 sends signature packets before the handshake to make VPN traffic look like some other UDP protocol. I1 defaults to a QUIC Initial packet (RFC 9000).
 
 | Tag | Description | Example |
 |-----|-------------|---------|
@@ -191,11 +227,11 @@ AWG 2.0 sends CPS packets before handshakes to masquerade VPN traffic as another
 | `<rc N>` | N random chars (a-zA-Z) | `<rc 16>` |
 | `<t>` | 32-bit Unix timestamp | |
 
-Use [AmneziaWG Architect](https://architect.vai-rice.space/) to generate custom CPS configs for QUIC, DNS, DTLS, SIP, HTTP/3 and more.
+[AmneziaWG Architect](https://architect.vai-rice.space/) generates signature strings for QUIC, DNS, DTLS, SIP, HTTP/3 and others.
 
-### Custom SERVERPORT
+## Custom SERVERPORT
 
-The container always listens on port 51820 internally. When using a custom `SERVERPORT`, map the external port to the internal one:
+The container always listens on 51820 inside the network namespace. `SERVERPORT` only changes what peer configs advertise, so map the external port onto 51820:
 
 ```yaml
 environment:
@@ -204,43 +240,50 @@ ports:
   - 32948:51820/udp  # NOT 32948:32948/udp
 ```
 
-## Show Peer QR Codes
+## Managing peers
 
 ```bash
 docker exec amneziawg /app/show-peer 1 2 3
 docker exec amneziawg /app/show-peer laptop phone tablet
 ```
 
-## Support Info
+## Support info
 
 ```bash
-# Container logs
+# container logs
 docker logs amneziawg
 
-# Interface status
+# interface status
 docker exec amneziawg awg show
 
-# Shell access
+# bundled amneziawg-go and amneziawg-tools versions
+docker exec amneziawg cat /build_version
+
+# shell access
 docker exec -it amneziawg /bin/bash
 ```
 
-## Building Locally
+## Building locally
 
 ```bash
 docker build -t amneziawg .
-# Multi-arch:
+# multi-arch:
 docker buildx build --platform linux/amd64,linux/arm64 -t amneziawg .
 ```
 
 ## Links
 
-- [AmneziaVPN Documentation](https://docs.amnezia.org/)
-- [AmneziaWG Kernel Module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
-- [AmneziaWG Architect](https://architect.vai-rice.space/) — GUI config generator for custom I1-I5 signatures
-- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) — Bash installer for AmneziaWG 2.0 on Ubuntu/Debian
-- [Advanced Hub Mode](ADVANCED_AWG_HUB.md) — server + client in one container with upstream VPN routing
-- [LinuxServer docker-wireguard](https://github.com/linuxserver/docker-wireguard) — inspiration for this project
+- [AmneziaVPN documentation](https://docs.amnezia.org/)
+- [AmneziaWG kernel module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
+- [AmneziaWG Architect](https://architect.vai-rice.space/), a GUI config generator for custom I1-I5 signatures
+- [amneziawg-installer](https://github.com/bivlked/amneziawg-installer), a bash installer for AmneziaWG 2.0 on Ubuntu/Debian
+- [Advanced hub mode](ADVANCED_AWG_HUB.md), server and client in one container with upstream VPN routing
+- [LinuxServer docker-wireguard](https://github.com/linuxserver/docker-wireguard), the project this one is modeled on
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Security issues go through [SECURITY.md](SECURITY.md).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file.
+MIT, see [LICENSE](LICENSE).


### PR DESCRIPTION
## What

The image has been shipping `amneziawg-go` **v3.1.20260814** and `amneziawg-tools` **v3.1.20260812** since the last upstream bump, but nothing in the repo documented what 3.1 changed. This adds that documentation and gives the README a structural pass.

## AWG 3.1

Upstream added two `[Interface]` booleans rather than a new parameter generation, so there is **no `AWG_VERSION=3.1`**. Verified against `amneziawg-go@1f50ad73` (`feat: awg 3.1 features`) and `amneziawg-tools` `src/config.c` at `v3.1.20260812`:

| Option | Effect | Both ends? |
|---|---|:---:|
| `RandomTrailers = on` | Random-length trailer on handshake initiation, response and cookie-reply packets (filling up to a 500-byte window), so they no longer have a fixed size | Yes |
| `DisableCookies = on` | Suppresses cookie-reply messages under load, removing a distinctive probe response, at the cost of the built-in DoS mitigation | No |

`RandomTrailers` is the one to be careful with. `DeterminePacketTypeAndPadding` in `device/receive.go` only accepts an oversized handshake packet when `randomTrailers` is set locally, so a peer without it silently drops the padded handshakes. Enable on server and every peer, or on none. The README says so explicitly.

Both work on the userspace and kernel datapaths (`ipc-uapi.h` and `ipc-linux.h` both carry the keys), and the kernel module needs to be v3.1.x. Older `awg` builds reject the keys with `Line unrecognized`.

Neither option is generated by the container, so they are documented as manual edits to `/config/templates/*.conf` or to your own client configs — not as env vars that do not exist.

## README restructure

- Quick start moved to the top. It previously sat 45 lines down, behind an architecture table, the modes explanation, the kernel-module paragraph and the whole protocol-version discussion.
- Table of contents added (the file is ~290 lines).
- GitHub `> [!NOTE]` / `> [!IMPORTANT]` alerts replace hand-bolded blockquotes.
- Sentence-case headings; the two-row "Supported Architectures" table folded into a Requirements bullet.
- `## Contributing` section added — `CONTRIBUTING.md` and `SECURITY.md` existed but nothing linked to them.
- Prose passed through the humanizer skill: em dashes 11 → 0, body bold → 0, plus the usual filler and copula-avoidance cleanup.
- `docker exec amneziawg cat /build_version` added to Support info.

## Verification

- All 13 TOC anchors and all 13 inline anchor links resolve against actual headings.
- Diffed the documented env vars and capabilities against `master`: **nothing dropped, nothing invented.**
- Peer config file paths (`config/peer_laptop/peer_laptop.conf`, `config/peer1/peer1.conf`) checked against the `PEER_ID` logic in `init-amneziawg-confs/run:394`. Previously undocumented.

## Not in this PR

`RandomTrailers` / `DisableCookies` have no `AWG_*` env vars and are absent from `generate_awg_params` and the `awg_params` persistence file, so today they are template-edit-only. Wiring up `AWG_RANDOM_TRAILERS` / `AWG_DISABLE_COOKIES` — including enforcing the both-ends invariant across the server and peer configs — is a code change and belongs on its own branch. The CHANGELOG also has no entry for the 3.1 bump yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)