### PR TITLE
ci: skip image rebuild and release for pushes that do not change the image

### DIFF
--- a/.claude/skills/docker-amneziawg/SKILL.md
+++ b/.claude/skills/docker-amneziawg/SKILL.md
@@ -136,7 +136,8 @@ Tunnel startup fails without `--device /dev/net/tun` — expected in testing.
 ## GitHub Actions Workflows
 
 ### docker-build.yml
-- Push to `master`/`main` -> builds multi-arch and tags as `latest` + tools version
+- A `changes` gate diffs each push/PR: only `Dockerfile`, `root/**`, `.dockerignore` and the workflow itself trigger a build. Docs/skills-only pushes skip build+release. Tags and `workflow_dispatch` always build
+- Push to `master`/`main` touching image paths -> builds multi-arch and tags as `latest` + tools version
 - Push `v*` tags -> semantic version tags (1.0.0, 1.0, 1)
 - Pull requests -> single-platform smoke test (no push)
 - `workflow_dispatch` accepts version overrides

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,67 @@ env:
   # workflow_dispatch inputs override them for one-off builds.
 
 jobs:
+  # Decide whether this event touches the image at all. Only Dockerfile, root/,
+  # .dockerignore and this workflow end up in (or shape) the published image —
+  # docs, skills and compose examples do not, so a push that changes only those
+  # must not rebuild and republish :latest / the tools-version tag.
+  #
+  # This is a diff gate rather than an `on.push.paths` filter on purpose: the
+  # push block also carries the v* tag trigger, and path filters behave
+  # ambiguously for tag pushes (no reliable before/after diff), which could
+  # silently break semver releases. An explicit gate fails open instead.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether image-affecting paths changed
+        id: filter
+        run: |
+          IMAGE_PATHS='^(Dockerfile$|root/|\.dockerignore$|\.github/workflows/docker-build\.yml$)'
+
+          # Anything that is not a plain branch push builds unconditionally:
+          # tag pushes (semver releases), manual dispatch (version overrides).
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.ref_type }}" == "tag" ]]; then
+            echo "image=true" >> "$GITHUB_OUTPUT"
+            echo "build: yes (${{ github.event_name }}/${{ github.ref_type }})" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          # New branch or force-push where the old tip is gone: no diff to
+          # inspect, so fail open and build.
+          if [[ "$BASE" =~ ^0+$ ]] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "image=true" >> "$GITHUB_OUTPUT"
+            echo "build: yes (no comparable base commit)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          echo "changed files:"; echo "$CHANGED" | sed 's/^/  /'
+          if echo "$CHANGED" | grep -qE "$IMAGE_PATHS"; then
+            echo "image=true" >> "$GITHUB_OUTPUT"
+            echo "build: yes (image-affecting paths changed)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "image=false" >> "$GITHUB_OUTPUT"
+            echo "build: skipped — no changes to Dockerfile, root/, .dockerignore or this workflow" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.image == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `docker-build.yml` now gates the multi-arch build and release behind a `changes` job that diffs the push: only `Dockerfile`, `root/**`, `.dockerignore` and the workflow itself are image content, so docs/skills/compose-only merges to master no longer rebuild and republish `:latest`. Tag pushes, `workflow_dispatch` and diffs with no reachable base always build. Implemented as an explicit `git diff` gate rather than an `on.push.paths` filter, which shares the push block with the `v*` tag trigger and is ambiguous for tag pushes
 - `docs/awg-performance.md`: measured throughput and latency cost of every obfuscation parameter, traced to upstream kernel-module and `amneziawg-go` source, with reproduction steps
 - `README.md` "Speed and latency" section, and data-path cost notes in `CONTEXT.md` and both skill references
 - `scripts/gen-awg-params.sh` (deploy skill) now enforces the performance constraints as well as the protocol ones: `S1 == S2 == S3 == S4` when `RandomTrailers` is on with AWG 2.0+ H ranges, `S4 <= 20` so the default 1420 MTU does not fragment, and `AWG_CONTENT_PADDING=0` unless `--content-padding on` is passed. It refuses `--content-padding on` together with `--random-trailers on`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ All clients and server must use identical values. Key constraints:
 ### Workflows
 
 **`docker-build.yml`** — main build pipeline:
-- Push to `master`/`main` → builds multi-arch (`amd64`, `arm64`) and pushes to `ghcr.io/ayastrebov/docker-amneziawg:latest` + upstream tools version tag, then creates a GitHub Release tagged with the tools version (skipped if the release already exists)
+- A `changes` gate job diffs each push/PR first: only `Dockerfile`, `root/**`, `.dockerignore` and the workflow itself are image content, so docs/skills/compose-only pushes skip the build and release entirely. The gate is an explicit `git diff` job, NOT an `on.push.paths` filter — path filters share the `push` block with the `v*` tag trigger and behave ambiguously for tag pushes, which could silently break semver releases. Tags, `workflow_dispatch`, and diffs with no reachable base all fail open (build)
+- Push to `master`/`main` touching image paths → builds multi-arch (`amd64`, `arm64`) and pushes to `ghcr.io/ayastrebov/docker-amneziawg:latest` + upstream tools version tag, then creates a GitHub Release tagged with the tools version (skipped if the release already exists)
 - `v*` tags → semantic version tags (`1.0.0`, `1.0`, `1`)
 - PRs → smoke tests only (single-platform `--load` build, no multi-arch QEMU): binaries, s6 structure, service types, dependency chain, CoreDNS, branding
 - Upstream versions are read from the Dockerfile `ARG` pins (single source of truth); `workflow_dispatch` accepts `amneziawg_go_version` and `amneziawg_tools_version` overrides for one-off builds

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -179,7 +179,8 @@ Guidance (documented in README "MTU"): 1280 for mobile/PPPoE/unknown paths (IPv6
 
 ### docker-build.yml
 
-- Push to `master`/`main` -> multi-arch build (`amd64`, `arm64`) -> `ghcr.io/ayastrebov/docker-amneziawg:latest` + tools version tag
+- A `changes` gate job runs first and skips build+release when a push/PR touches nothing image-affecting. Image content is `Dockerfile`, `root/**`, `.dockerignore` and the workflow itself; docs, skills and compose examples never reach the image. Tag pushes, `workflow_dispatch` and unreachable-base diffs fail open (always build)
+- Push to `master`/`main` touching image paths -> multi-arch build (`amd64`, `arm64`) -> `ghcr.io/ayastrebov/docker-amneziawg:latest` + tools version tag
 - `v*` tags -> semantic version tags (`1.0.0`, `1.0`, `1`)
 - PRs -> smoke tests only (single-platform `--load` build): binaries, s6 structure, service types, dependency chain, CoreDNS, branding
 - `workflow_dispatch` accepts `amneziawg_go_version` and `amneziawg_tools_version` overrides


### PR DESCRIPTION
## Problem

Every merge to master rebuilds the multi-arch image (~15-20 min with QEMU), re-pushes `:latest` + the tools-version tag, and runs the release job — even for docs-only merges that change nothing in the image.

## Change

A `changes` gate job diffs each push/PR before anything builds. Image content is exactly `Dockerfile`, `root/**`, `.dockerignore` and the workflow itself — docs, skills and compose examples never reach the image (`COPY /root /` is the only content COPY).

| Push touches | Result |
|---|---|
| docs / skills / CHANGELOG only | build + release **skipped** |
| `root/**` (script fixes, e.g. the I2-I5 fix) | builds + publishes |
| `Dockerfile` (upstream version bumps from `upstream-check.yml`) | builds + publishes + release |
| `v*` tag, `workflow_dispatch` | always builds |
| force-push / unreachable base | fails open, builds |

Note this is deliberately broader than "only when amneziawg-go/tools were updated": gating on ARG bumps alone would have blocked shipping `root/` script fixes until the next upstream release.

Implemented as an explicit `git diff` job rather than `on.push.paths`, because the push block also carries the `v*` tag trigger and path filters are ambiguous for tag pushes — an explicit gate fails open instead of silently breaking semver releases.

## Verification

- Workflow YAML parses; `actionlint` reports only the pre-existing `config-inline` deprecation
- The path regex was tested against eight representative diffs, including lookalike names (`Dockerfile.dev`, `rootless/`) that must not match
- `release` needs `build`, so it cascade-skips with the gate — no `if` changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)